### PR TITLE
Fix Z2B Railway deployment by adding explicit service configuration

### DIFF
--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "nixpacks"
+
+[deploy]
+startCommand = "uvicorn app.main:app --host 0.0.0.0 --port $PORT"
+healthcheckPath = "/health"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3


### PR DESCRIPTION
Add railway.toml to backend directory to explicitly configure the start command and health check settings. This resolves the deployment failure where Railway was attempting to run 'yarn start' in a Python container.

The configuration ensures Railway uses the correct uvicorn command to start the FastAPI application on the PORT environment variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)